### PR TITLE
Extended messages cannot have required fields (must be optional).

### DIFF
--- a/resources/search.php
+++ b/resources/search.php
@@ -15,6 +15,20 @@ GNU Affero General Public License for more details.
 You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see http://www.fsf.org/licensing/licenses/agpl-3.0.html. */
 
+/*****************************************************************************
+ * Important change to php.ini:                                              *
+ *****************************************************************************
+ * You MUST set always_populate_raw_post_data=1 in your php.ini to get this  *
+ * working!). E.g. I had to set this in FPM's seeks.conf:                    *
+ * php_admin_value[always_populate_raw_post_data] = 1                        *
+ *****************************************************************************
+ * My file is located at /etc/php5/fpm/pool.d/seeks.conf.                    *
+ *****************************************************************************
+ */
+
+// Let's fix all of them
+error_reporting(E_ALL | E_STRICT);
+
 // Default is HTTP
 $scheme = 'http://';
 
@@ -72,25 +86,35 @@ curl_setopt($curl, CURLOPT_CUSTOMREQUEST, $_SERVER['REQUEST_METHOD']);
 
 if (isset($bqc[0]) && $bqc[0] == 'find_bqc') {
 	$postdata = file_get_contents('php://input');
+
+	// For debugging purposes
+	//* DEBUG: */ file_put_contents('/tmp/foo', ini_get('always_populate_raw_post_data') . ':' . $postdata);
+
 	curl_setopt($curl, CURLOPT_POST, 1);
 	curl_setopt($curl, CURLOPT_POSTFIELDS, $postdata);
 }
 
 curl_setopt($curl, CURLOPT_PROXY, $proxy);
-curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1) ;
+curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
 
-curl_setopt($curl, CURLOPT_HTTPHEADER, array('X-Seeks-Remote-Location: ' . $base_url, 'Accept-Language: ' . $lang_head, 'Referer: ' . $referer));
+curl_setopt($curl, CURLOPT_HTTPHEADER, array('X-Seeks-Remote-Location: ' . $base_url, 'Accept-Language: ' . $lang_head, 'Proxy-Connection: Close', 'Expect:', 'Referer: ' . $referer));
 
 $result = curl_exec($curl);
 $result_info = curl_getinfo($curl);
 
-syslog(LOG_INFO, 'result_info=' . json_encode($result_info));
+// Very noisy in syslog:
+//* NOISY-DEBUG: */ syslog(LOG_INFO, 'result_info=' . json_encode($result_info));
 
-if(curl_errno($curl)) {
+if (curl_errno($curl)) {
 	echo 'CURL ERROR: '.curl_error($curl);
 }
 
 curl_close($curl);
+
+if (headers_sent()) {
+	// Headers are already sent, cannot continue, maybe error?
+	exit();
+}
 
 header('Content-Type: ' . $result_info['content_type']);
 
@@ -113,5 +137,8 @@ if ((isset($qc_redir[0]) && $qc_redir[0] == 'qc_redir') || (isset($tbd[0]) && $t
 	}
 }
 
+// Very noisy in syslog:
+//* NOISY-DEBUG: */ syslog(LOG_INFO, 'result=' . json_encode($result));
 echo $result;
+
 ?>

--- a/resources/search.php
+++ b/resources/search.php
@@ -15,18 +15,40 @@ GNU Affero General Public License for more details.
 You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see http://www.fsf.org/licensing/licenses/agpl-3.0.html. */
 
-if($_SERVER['HTTPS']) $scheme = 'https://';
-else $scheme= 'http://';
+// Default is HTTP
+$scheme = 'http://';
+
+if (isset($_SERVER['HTTPS'])) {
+	$scheme = 'https://';
+}
 
 $seeks_uri = 'http://s.s';
 $proxy = 'localhost:8250';
 $base_script = $_SERVER['SCRIPT_NAME'];
 $base_url = $scheme.$_SERVER['HTTP_HOST'].$base_script;
 
-if ($_SERVER['REQUEST_URI'] == '/search.php') { header('Location: '.$base_url.'/websearch-hp'); }
-else $url = $seeks_uri.str_replace($base_script, '', $_SERVER['REQUEST_URI']);
-$lang_head = $_SERVER['HTTP_ACCEPT_LANGUAGE'];
-$referer = $_SERVER['HTTP_REFERER'];
+if ($_SERVER['REQUEST_URI'] == '/search.php') {
+	header('Location: '.$base_url.'/websearch-hp');
+
+	// Don't miss exit() as the server redirect doesn't abort the script
+	exit();
+} else {
+	$url = $seeks_uri . str_replace($base_script, '', $_SERVER['REQUEST_URI']);
+}
+
+// Avoid E_NOTICE by initializing variables and checking on array elements
+$lang_head = '';
+$referer = '';
+
+// Not all browsers are sending this header
+if (isset($_SERVER['HTTP_ACCEPT_LANGUAGE'])) {
+	$lang_head = $_SERVER['HTTP_ACCEPT_LANGUAGE'];
+}
+
+// Not all browsers are sending this header
+if (isset($_SERVER['HTTP_REFERER'])) {
+	$referer = $_SERVER['HTTP_REFERER'];
+}
 
 $qc_redir = array();
 preg_match('/qc_redir/', $url, $qc_redir);
@@ -39,42 +61,46 @@ preg_match('/find_bqc/', $url, $bqc);
 
 $curl = curl_init();
 curl_setopt($curl, CURLOPT_URL, $url);
-if ($qc_redir[0] == "qc_redir"
-   || $tbd[0] == "tbd")
-{
- curl_setopt($curl, CURLOPT_HEADER, true);
+
+if ($qc_redir[0] == 'qc_redir' || $tbd[0] == 'tbd') {
+	curl_setopt($curl, CURLOPT_HEADER, true);
 }
+
 curl_setopt($curl, CURLOPT_CUSTOMREQUEST, $_SERVER['REQUEST_METHOD']);
-if ($bqc[0] == "find_bqc")
-{
- $postdata = file_get_contents("php://input");
- curl_setopt($curl, CURLOPT_POST, 1);
- curl_setopt($curl, CURLOPT_POSTFIELDS, $postdata);
+
+if ($bqc[0] == 'find_bqc') {
+	$postdata = file_get_contents('php://input');
+	curl_setopt($curl, CURLOPT_POST, 1);
+	curl_setopt($curl, CURLOPT_POSTFIELDS, $postdata);
 }
+
 curl_setopt($curl, CURLOPT_PROXY, $proxy);
 curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1) ;
-curl_setopt($curl, CURLOPT_HTTPHEADER, array("Seeks-Remote-Location: ".$base_url,"Accept-Language: ".$lang_head,"Referer: " .$referer));
+curl_setopt($curl, CURLOPT_HTTPHEADER, array('Seeks-Remote-Location: '.$base_url, 'Accept-Language: '.$lang_head, 'Referer: '.$referer));
 $result = curl_exec($curl);
 $result_info = curl_getinfo($curl);
-if(curl_errno($curl)) echo 'CURL ERROR: '.curl_error($curl);
+
+if(curl_errno($curl)) {
+	echo 'CURL ERROR: '.curl_error($curl);
+}
+
 curl_close($curl);
 
 header('Content-Type: '.$result_info['content_type']);
 
-if ($qc_redir[0] == "qc_redir"
-   || $tbd[0] == "tbd")
-{
- $status_code = array(); 
- preg_match('/\d\d\d/', $result, $status_code);
- switch( $status_code[0] ) {
-  case 302:
-  $location = array();
-  preg_match('/Location: (.*)/', $result, $location);
-  $location[0] = substr($location[0],10);
-  header("Location: ". $location[0]);
-  break; 
-  default:
- }
+if ($qc_redir[0] == 'qc_redir' || $tbd[0] == 'tbd') {
+	preg_match('/\d\d\d/', $result, $status_code);
+
+	switch( $status_code[0] ) {
+	case 302:
+		$location = array();
+		preg_match('/Location: (.*)/', $result, $location);
+		$location[0] = substr($location[0],10);
+		header('Location: '. $location[0]);
+
+		// Don't miss exit() as the server redirect doesn't abort the script
+		exit();
+	}
 }
 
 echo $result;

--- a/resources/search.php
+++ b/resources/search.php
@@ -1,4 +1,4 @@
-<?
+<?php
 
 /* Copyright Camille Harang, Pablo Joubert, Emmanuel Benazera
 

--- a/resources/search.php
+++ b/resources/search.php
@@ -79,8 +79,7 @@ if ($bqc[0] == 'find_bqc') {
 curl_setopt($curl, CURLOPT_PROXY, $proxy);
 curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1) ;
 
-// @TODO Seeks-Remote-Location is NO default header, always prefix with X-!!!
-curl_setopt($curl, CURLOPT_HTTPHEADER, array('Seeks-Remote-Location: ' . $base_url, 'Accept-Language: ' . $lang_head, 'Referer: ' . $referer));
+curl_setopt($curl, CURLOPT_HTTPHEADER, array('X-Seeks-Remote-Location: ' . $base_url, 'Accept-Language: ' . $lang_head, 'Referer: ' . $referer));
 
 $result = curl_exec($curl);
 $result_info = curl_getinfo($curl);

--- a/resources/search.php
+++ b/resources/search.php
@@ -18,22 +18,24 @@ along with this program. If not, see http://www.fsf.org/licensing/licenses/agpl-
 // Default is HTTP
 $scheme = 'http://';
 
+// Is HTTPS set?
 if (isset($_SERVER['HTTPS'])) {
+	// Then assume https:// shall be used
 	$scheme = 'https://';
 }
 
 $seeks_uri = 'http://s.s';
 $proxy = 'localhost:8250';
-$base_script = $_SERVER['SCRIPT_NAME'];
-$base_url = $scheme.$_SERVER['HTTP_HOST'].$base_script;
+
+$base_url = $scheme . $_SERVER['HTTP_HOST'] . $_SERVER['SCRIPT_NAME'];
 
 if ($_SERVER['REQUEST_URI'] == '/search.php') {
-	header('Location: '.$base_url.'/websearch-hp');
+	header('Location: ' . $base_url . '/websearch-hp');
 
 	// Don't miss exit() as the server redirect doesn't abort the script
 	exit();
 } else {
-	$url = $seeks_uri . str_replace($base_script, '', $_SERVER['REQUEST_URI']);
+	$url = $seeks_uri . str_replace($_SERVER['SCRIPT_NAME'], '', $_SERVER['REQUEST_URI']);
 }
 
 // Avoid E_NOTICE by initializing variables and checking on array elements
@@ -76,7 +78,10 @@ if ($bqc[0] == 'find_bqc') {
 
 curl_setopt($curl, CURLOPT_PROXY, $proxy);
 curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1) ;
-curl_setopt($curl, CURLOPT_HTTPHEADER, array('Seeks-Remote-Location: '.$base_url, 'Accept-Language: '.$lang_head, 'Referer: '.$referer));
+
+// @TODO Seeks-Remote-Location is NO default header, always prefix with X-!!!
+curl_setopt($curl, CURLOPT_HTTPHEADER, array('Seeks-Remote-Location: ' . $base_url, 'Accept-Language: ' . $lang_head, 'Referer: ' . $referer));
+
 $result = curl_exec($curl);
 $result_info = curl_getinfo($curl);
 

--- a/resources/search.php
+++ b/resources/search.php
@@ -84,13 +84,15 @@ curl_setopt($curl, CURLOPT_HTTPHEADER, array('X-Seeks-Remote-Location: ' . $base
 $result = curl_exec($curl);
 $result_info = curl_getinfo($curl);
 
+syslog(LOG_INFO, 'result_info=' . json_encode($result_info));
+
 if(curl_errno($curl)) {
 	echo 'CURL ERROR: '.curl_error($curl);
 }
 
 curl_close($curl);
 
-header('Content-Type: '.$result_info['content_type']);
+header('Content-Type: ' . $result_info['content_type']);
 
 if ((isset($qc_redir[0]) && $qc_redir[0] == 'qc_redir') || (isset($tbd[0]) && $tbd[0] == 'tbd')) {
 	preg_match('/\d\d\d/', $result, $status_code);
@@ -104,6 +106,10 @@ if ((isset($qc_redir[0]) && $qc_redir[0] == 'qc_redir') || (isset($tbd[0]) && $t
 
 		// Don't miss exit() as the server redirect doesn't abort the script
 		exit();
+
+	default:
+		syslog(LOG_WARNING, 'Status code ' . $status_code[0] . ' found.');
+		break;
 	}
 }
 

--- a/resources/search.php
+++ b/resources/search.php
@@ -64,13 +64,13 @@ preg_match('/find_bqc/', $url, $bqc);
 $curl = curl_init();
 curl_setopt($curl, CURLOPT_URL, $url);
 
-if ($qc_redir[0] == 'qc_redir' || $tbd[0] == 'tbd') {
+if ((isset($qc_redir[0]) && $qc_redir[0] == 'qc_redir') || (isset($tbd[0]) && $tbd[0] == 'tbd')) {
 	curl_setopt($curl, CURLOPT_HEADER, true);
 }
 
 curl_setopt($curl, CURLOPT_CUSTOMREQUEST, $_SERVER['REQUEST_METHOD']);
 
-if ($bqc[0] == 'find_bqc') {
+if (isset($bqc[0]) && $bqc[0] == 'find_bqc') {
 	$postdata = file_get_contents('php://input');
 	curl_setopt($curl, CURLOPT_POST, 1);
 	curl_setopt($curl, CURLOPT_POSTFIELDS, $postdata);
@@ -92,14 +92,14 @@ curl_close($curl);
 
 header('Content-Type: '.$result_info['content_type']);
 
-if ($qc_redir[0] == 'qc_redir' || $tbd[0] == 'tbd') {
+if ((isset($qc_redir[0]) && $qc_redir[0] == 'qc_redir') || (isset($tbd[0]) && $tbd[0] == 'tbd')) {
 	preg_match('/\d\d\d/', $result, $status_code);
 
 	switch( $status_code[0] ) {
 	case 302:
 		$location = array();
 		preg_match('/Location: (.*)/', $result, $location);
-		$location[0] = substr($location[0],10);
+		$location[0] = substr($location[0], 10);
 		header('Location: '. $location[0]);
 
 		// Don't miss exit() as the server redirect doesn't abort the script

--- a/resources/search.php
+++ b/resources/search.php
@@ -97,7 +97,7 @@ if (isset($bqc[0]) && $bqc[0] == 'find_bqc') {
 curl_setopt($curl, CURLOPT_PROXY, $proxy);
 curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
 
-curl_setopt($curl, CURLOPT_HTTPHEADER, array('X-Seeks-Remote-Location: ' . $base_url, 'Accept-Language: ' . $lang_head, 'Proxy-Connection: Close', 'Expect:', 'Referer: ' . $referer));
+curl_setopt($curl, CURLOPT_HTTPHEADER, array('Seeks-Remote-Location: ' . $base_url, 'Accept-Language: ' . $lang_head, 'Proxy-Connection: Close', 'Expect:', 'Referer: ' . $referer));
 
 $result = curl_exec($curl);
 $result_info = curl_getinfo($curl);

--- a/src/cli/Makefile.am
+++ b/src/cli/Makefile.am
@@ -5,7 +5,7 @@ seeksclidatadir = $(datadir)/seeks/cli
 
 AM_CXXFLAGS=-Wall -g -pipe
 AM_CPPFLAGS=-I${srcdir} -I${srcdir}/../proxy -I${srcdir}/../utils -I${srcdir}/../lsh \
-            @CURL_CFLAGS@
+            -I${srcdir}/../plugins/udb_service @CURL_CFLAGS@
 
 seeksclilib_LIBRARIES=libseekscli.a
 libseekscli_a_SOURCES=cli.cpp ../proxy/encode.cpp ../utils/miscutil.cpp cli.h

--- a/src/plugins/cf/tests/ut-cf-sre.cpp
+++ b/src/plugins/cf/tests/ut-cf-sre.cpp
@@ -563,7 +563,7 @@ TEST_F(SRETest,recommendation_post_url_check_retrieve)
   http_response rsp;
   hash_map<const char*,const char*,hash<const char*>,eqstr> *parameters
   = new hash_map<const char*,const char*,hash<const char*>,eqstr>();
-  miscutil::add_map_entry(parameters,"url",1,"http://seeks.mxchange.org/",1);
+  miscutil::add_map_entry(parameters,"url",1,"http://seeks-project.info/",1);
   miscutil::add_map_entry(parameters,"url-check",1,"0",1);
   miscutil::add_map_entry(parameters,"radius",1,"5",1);
   miscutil::add_map_entry(parameters,"output",1,"json",1);

--- a/src/plugins/cf/tests/ut-cf-sre.cpp
+++ b/src/plugins/cf/tests/ut-cf-sre.cpp
@@ -563,7 +563,7 @@ TEST_F(SRETest,recommendation_post_url_check_retrieve)
   http_response rsp;
   hash_map<const char*,const char*,hash<const char*>,eqstr> *parameters
   = new hash_map<const char*,const char*,hash<const char*>,eqstr>();
-  miscutil::add_map_entry(parameters,"url",1,"http://www.seeks.fr/",1);
+  miscutil::add_map_entry(parameters,"url",1,"http://seeks.mxchange.org/",1);
   miscutil::add_map_entry(parameters,"url-check",1,"0",1);
   miscutil::add_map_entry(parameters,"radius",1,"5",1);
   miscutil::add_map_entry(parameters,"output",1,"json",1);

--- a/src/plugins/cf/tests/ut-peer-list.cpp
+++ b/src/plugins/cf/tests/ut-peer-list.cpp
@@ -81,6 +81,7 @@ TEST(WCFTest,cgi_peers)
   cf_configuration::_config = new cf_configuration("");
   cf_configuration::_config->_pl->add("seeks.fr",-1,"","bsn");
   cf_configuration::_config->_pl->add("seeks-project.info",-1,"/search.php","bsn");
+  // @TODO Wont' work, as search_exp.php is not available?
   cf_configuration::_config->_pl->add("seeks-project.info",-1,"/search_exp.php","bsn");
   client_state csp;
   http_response rsp;

--- a/src/plugins/httpserv/httpserv.cpp
+++ b/src/plugins/httpserv/httpserv.cpp
@@ -1110,6 +1110,8 @@ t.dtd\"><html><head><title>408 - Seeks fail connection to background search engi
 
   void httpserv::find_bqc(struct evhttp_request *r, void *arg)
   {
+    errlog::log_error(LOG_LEVEL_DEBUG, "httpserv::find_bqc(): CALLED!");
+
     client_state csp;
     csp._config = seeks_proxy::_config;
     http_response *rsp = new http_response();
@@ -1171,6 +1173,7 @@ t.dtd\"><html><head><title>408 - Seeks fail connection to background search engi
                                            input_buffer->off / sizeof(u_char));
 #endif
 
+    errlog::log_error(LOG_LEVEL_DEBUG, "httpserv::find_bqc(): post_content=%s,length()=%d", post_content.c_str(), post_content.length());
     if (post_content.empty())
       {
         httpserv::reply_with_error_400(r); //TODO: proper error type.
@@ -1191,6 +1194,7 @@ t.dtd\"><html><head><title>408 - Seeks fail connection to background search engi
       miscutil::enlist_unique_header(&csp._headers,"host",host);
 
     // call to find_bqc callback.
+    errlog::log_error(LOG_LEVEL_DEBUG, "httpserv::find_bqc(): csp._iob._cur=%s", csp._iob._cur);
     sp_err serr = udb_service::cgi_find_bqc(&csp,rsp,parameters);
     miscutil::list_remove_all(&csp._headers);
     delete[] csp._iob._cur;

--- a/src/plugins/query_capture/db_query_record_msg.proto
+++ b/src/plugins/query_capture/db_query_record_msg.proto
@@ -33,5 +33,5 @@ message related_query
 
 extend sp.db.record
 {
- required related_queries queries = 20; /* original queries */
+ optional related_queries queries = 20; /* original queries */
 }

--- a/src/plugins/query_capture/query_capture.cpp
+++ b/src/plugins/query_capture/query_capture.cpp
@@ -650,7 +650,7 @@ namespace seeks_plugins
                 referer = "";
               }
           }
-        else if (miscutil::strncmpic((*lit),"X-Seeks-Remote-Location:",22) == 0)
+        else if (miscutil::strncmpic((*lit),"-Seeks-Remote-Location:",22) == 0)
           {
             base_url = (*lit);
             try

--- a/src/plugins/query_capture/query_capture.cpp
+++ b/src/plugins/query_capture/query_capture.cpp
@@ -650,7 +650,7 @@ namespace seeks_plugins
                 referer = "";
               }
           }
-        else if (miscutil::strncmpic((*lit),"Seeks-Remote-Location:",22) == 0)
+        else if (miscutil::strncmpic((*lit),"X-Seeks-Remote-Location:",22) == 0)
           {
             base_url = (*lit);
             try

--- a/src/plugins/udb_service/halo_msg_wrapper.cpp
+++ b/src/plugins/udb_service/halo_msg_wrapper.cpp
@@ -29,6 +29,8 @@ namespace seeks_plugins
                                      uint32_t &expansion,
                                      std::vector<std::string> &hashes) throw (sp_exception)
   {
+    errlog::log_error(LOG_LEVEL_DEBUG, "halo_msg_wrapper::deserialize(): msg=%s,expansion=%d -  CALLED!", msg.c_str(), expansion);
+
     hash_halo h;
     if (!h.ParseFromString(msg))
       {
@@ -39,14 +41,19 @@ namespace seeks_plugins
     expansion = h.expansion();
     for (int i=0; i<h.key_size(); i++)
       hashes.push_back(h.key(i));
+
+    errlog::log_error(LOG_LEVEL_DEBUG, "halo_msg_wrapper::deserialize(): msg=%s,expansion=%d -  EXIT!", msg.c_str(), expansion);
   }
 
   void halo_msg_wrapper::serialize(const uint32_t &expansion,
                                    const hash_multimap<uint32_t,DHTKey,id_hash_uint> &qhashes,
                                    std::string &msg) throw (sp_exception)
   {
+    errlog::log_error(LOG_LEVEL_DEBUG, "halo_msg_wrapper::serialize(): msg=%s,expansion=%d - CALLED!", msg.c_str(), expansion);
+
     hash_halo h;
     h.set_expansion(expansion);
+    errlog::log_error(LOG_LEVEL_DEBUG, "halo_msg_wrapper::serialize(): h.expansion()=%d", h.expansion());
     hash_multimap<uint32_t,DHTKey,id_hash_uint>::const_iterator hit = qhashes.begin();
     while(hit!=qhashes.end())
       {
@@ -60,6 +67,7 @@ namespace seeks_plugins
         errlog::log_error(LOG_LEVEL_ERROR,msg.c_str());
         throw sp_exception(UDBS_ERR_SERIALIZE,msg);
       }
-  }
 
+    errlog::log_error(LOG_LEVEL_DEBUG, "halo_msg_wrapper::serialize(): msg=%s,expansion=%d - EXIT!", msg.c_str(), expansion);
+  }
 } /* end of namespace. */

--- a/src/plugins/udb_service/udb_client.cpp
+++ b/src/plugins/udb_service/udb_client.cpp
@@ -118,6 +118,7 @@ namespace seeks_plugins
     std::string msg;
     try
       {
+        errlog::log_error(LOG_LEVEL_DEBUG, "udb_client::find_bqc(): Calling halo_msg_wrapper::serialize(%d,???,%s) ...", expansion, msg.c_str());
         halo_msg_wrapper::serialize(expansion,qhashes,msg);
       }
     catch(sp_exception &e)
@@ -135,7 +136,7 @@ namespace seeks_plugins
     std::vector<std::string> urls;
     urls.reserve(1);
     urls.push_back(url);
-    errlog::log_error(LOG_LEVEL_DEBUG,"call: %s",url.c_str());
+    errlog::log_error(LOG_LEVEL_DEBUG, "udb_client::find_bqc(): url=%s,msg=%s,msg.length()=%d", url.c_str(), msg.c_str(), msg.length());
     std::vector<int> status;
     if (udb_service_configuration::_config->_p2p_proxy_addr.empty())
       cmg.www_mget(urls,1,NULL,"",0,status,
@@ -145,6 +146,7 @@ namespace seeks_plugins
                         udb_service_configuration::_config->_p2p_proxy_addr,
                         udb_service_configuration::_config->_p2p_proxy_port,
                         status,NULL,NULL,"POST",&msg,msg.length()*sizeof(char));
+    errlog::log_error(LOG_LEVEL_DEBUG, "udb_client::find_bqc(): status[0]=%d", status[0]);
     if (status[0] !=0)
       {
         // failed connection.

--- a/src/plugins/websearch/query_context.cpp
+++ b/src/plugins/websearch/query_context.cpp
@@ -590,6 +590,8 @@ namespace seeks_plugins
 
   std::string query_context::detect_base_url_http(client_state *csp)
   {
+    errlog::log_error(LOG_LEVEL_DEBUG, "query_context::detect_base_url_http(): CALLED!");
+
     std::list<const char*> headers = csp->_headers;
 
     // first we try to get base_url from a custom header
@@ -597,13 +599,14 @@ namespace seeks_plugins
     std::list<const char*>::const_iterator sit = headers.begin();
     while (sit!=headers.end())
       {
-        if (miscutil::strncmpic((*sit),"X-Seeks-Remote-Location:",22) == 0)
+        if (miscutil::strncmpic((*sit),"X-Seeks-Remote-Location:",24) == 0)
           {
             base_url = (*sit);
             size_t pos = base_url.find_first_of(" ");
             try
               {
                 base_url = base_url.substr(pos+1);
+                errlog::log_error(LOG_LEVEL_DEBUG, "query_context::detect_base_url_http(): base_url=%s found in headers", base_url.c_str());
               }
             catch (std::exception &e)
               {
@@ -638,7 +641,10 @@ namespace seeks_plugins
             ++sit;
           }
         base_url = csp->_http._ssl ? "https://" : "http://" + base_url;
+        errlog::log_error(LOG_LEVEL_DEBUG, "query_context::detect_base_url_http(): base_url=%s with no custom header", base_url.c_str());
       }
+
+    errlog::log_error(LOG_LEVEL_DEBUG, "query_context::detect_base_url_http(): base_url=%s - EXIT!", base_url.c_str());
     return base_url;
   }
 

--- a/src/plugins/websearch/query_context.cpp
+++ b/src/plugins/websearch/query_context.cpp
@@ -599,7 +599,7 @@ namespace seeks_plugins
     std::list<const char*>::const_iterator sit = headers.begin();
     while (sit!=headers.end())
       {
-        if (miscutil::strncmpic((*sit),"X-Seeks-Remote-Location:",24) == 0)
+        if (miscutil::strncmpic((*sit),"Seeks-Remote-Location:",22) == 0)
           {
             base_url = (*sit);
             size_t pos = base_url.find_first_of(" ");

--- a/src/plugins/websearch/query_context.cpp
+++ b/src/plugins/websearch/query_context.cpp
@@ -597,7 +597,7 @@ namespace seeks_plugins
     std::list<const char*>::const_iterator sit = headers.begin();
     while (sit!=headers.end())
       {
-        if (miscutil::strncmpic((*sit),"Seeks-Remote-Location:",22) == 0)
+        if (miscutil::strncmpic((*sit),"X-Seeks-Remote-Location:",22) == 0)
           {
             base_url = (*sit);
             size_t pos = base_url.find_first_of(" ");

--- a/src/plugins/websearch/static_renderer.cpp
+++ b/src/plugins/websearch/static_renderer.cpp
@@ -677,7 +677,7 @@ namespace seeks_plugins
     = cgi::default_exports(csp,"");
 
     // we need to inject a remote base location for remote web access.
-    // the injected header, if it exists is Seeks-Remote-Location
+    // the injected header, if it exists is X-Seeks-Remote-Location
     std::string base_url = query_context::detect_base_url_http(csp);
     miscutil::add_map_entry(exports,"base-url",1,base_url.c_str(),1);
 

--- a/src/plugins/websearch/static_renderer.cpp
+++ b/src/plugins/websearch/static_renderer.cpp
@@ -677,7 +677,7 @@ namespace seeks_plugins
     = cgi::default_exports(csp,"");
 
     // we need to inject a remote base location for remote web access.
-    // the injected header, if it exists is X-Seeks-Remote-Location
+    // the injected header, if it exists is Seeks-Remote-Location
     std::string base_url = query_context::detect_base_url_http(csp);
     miscutil::add_map_entry(exports,"base-url",1,base_url.c_str(),1);
 

--- a/src/plugins/websearch_api_compat/websearch_api_compat.cpp
+++ b/src/plugins/websearch_api_compat/websearch_api_compat.cpp
@@ -80,10 +80,11 @@ namespace seeks_plugins
       {
         // check for query.
         const char *query_str = miscutil::lookup(parameters,"q");
-        if (!query_str || strlen(query_str) == 0) {
-          errlog::log_error(LOG_LEVEL_ERROR, "Error SP_ERR_CGI_PARAMS: Parameter 'q' is not set or empty.");
-          return SP_ERR_CGI_PARAMS;
-        }
+        if (!query_str || strlen(query_str) == 0)
+          {
+            errlog::log_error(LOG_LEVEL_ERROR, "Error SP_ERR_CGI_PARAMS: Parameter 'q' is not set or empty.");
+            return SP_ERR_CGI_PARAMS;
+          }
 
         // cgi decodes the parameters, need to re-encode before passing it to websearch plugin.
         char *enc_query = encode::url_encode(query_str);
@@ -147,10 +148,11 @@ namespace seeks_plugins
       {
         // check for query.
         const char *query_str = miscutil::lookup(parameters,"q");
-        if (!query_str || strlen(query_str) == 0) {
-          errlog::log_error(LOG_LEVEL_ERROR, "Error SP_ERR_CGI_PARAMS: 'q' is not set or empty.");
-          return SP_ERR_CGI_PARAMS;
-        }
+        if (!query_str || strlen(query_str) == 0)
+          {
+            errlog::log_error(LOG_LEVEL_ERROR, "Error SP_ERR_CGI_PARAMS: 'q' is not set or empty.");
+            return SP_ERR_CGI_PARAMS;
+          }
         char *enc_query = encode::url_encode(query_str);
         std::string query = enc_query;
         free(enc_query);
@@ -158,10 +160,11 @@ namespace seeks_plugins
 
         // check for url.
         const char *url_str = miscutil::lookup(parameters,"url");
-        if (!url_str) {
-          errlog::log_error(LOG_LEVEL_ERROR, "Error SP_ERR_CGI_PARAMS: 'url' is not set or empty.");
-          return SP_ERR_CGI_PARAMS;
-        }
+        if (!url_str)
+          {
+            errlog::log_error(LOG_LEVEL_ERROR, "Error SP_ERR_CGI_PARAMS: 'url' is not set or empty.");
+            return SP_ERR_CGI_PARAMS;
+          }
         std::string url = url_str;
         std::transform(url.begin(),url.end(),url.begin(),tolower);
         std::string surl = urlmatch::strip_url(url);
@@ -190,10 +193,11 @@ namespace seeks_plugins
       {
         // check for query.
         const char *query_str = miscutil::lookup(parameters,"q");
-        if (!query_str || strlen(query_str) == 0) {
-          errlog::log_error(LOG_LEVEL_ERROR, "Error SP_ERR_CGI_PARAMS: 'q' is not set or empty.");
-          return SP_ERR_CGI_PARAMS;
-        }
+        if (!query_str || strlen(query_str) == 0)
+          {
+            errlog::log_error(LOG_LEVEL_ERROR, "Error SP_ERR_CGI_PARAMS: 'q' is not set or empty.");
+            return SP_ERR_CGI_PARAMS;
+          }
         char *enc_query = encode::url_encode(query_str);
         std::string query = enc_query;
         free(enc_query);
@@ -205,10 +209,11 @@ namespace seeks_plugins
 
         // check for url.
         const char *url_str = miscutil::lookup(parameters,"url");
-        if (!url_str) {
-          errlog::log_error(LOG_LEVEL_ERROR, "Error SP_ERR_CGI_PARAMS: 'url' is not set or empty.");
-          return SP_ERR_CGI_PARAMS;
-        }
+        if (!url_str)
+          {
+            errlog::log_error(LOG_LEVEL_ERROR, "Error SP_ERR_CGI_PARAMS: 'url' is not set or empty.");
+            return SP_ERR_CGI_PARAMS;
+          }
         std::string url = url_str;
         std::transform(url.begin(),url.end(),url.begin(),tolower);
         std::string surl = urlmatch::strip_url(url);
@@ -239,10 +244,11 @@ namespace seeks_plugins
       {
         // check for query.
         const char *query_str = miscutil::lookup(parameters,"q");
-        if (!query_str || strlen(query_str) == 0) {
-          errlog::log_error(LOG_LEVEL_ERROR, "Returning SP_ERR_CGI_PARAMS: Parameter 'q' not given.");
-          return SP_ERR_CGI_PARAMS;
-        }
+        if (!query_str || strlen(query_str) == 0)
+          {
+            errlog::log_error(LOG_LEVEL_ERROR, "Returning SP_ERR_CGI_PARAMS: Parameter 'q' not given.");
+            return SP_ERR_CGI_PARAMS;
+          }
         char *enc_query = encode::url_encode(query_str);
         std::string query = enc_query;
         free(enc_query);
@@ -250,10 +256,11 @@ namespace seeks_plugins
 
         // check for url.
         const char *url_str = miscutil::lookup(parameters,"url");
-        if (!url_str) {
-          errlog::log_error(LOG_LEVEL_ERROR, "Returning SP_ERR_CGI_PARAMS: Parameter 'url' not given.");
-          return SP_ERR_CGI_PARAMS;
-        }
+        if (!url_str)
+          {
+            errlog::log_error(LOG_LEVEL_ERROR, "Returning SP_ERR_CGI_PARAMS: Parameter 'url' not given.");
+            return SP_ERR_CGI_PARAMS;
+          }
         std::string url = url_str;
         std::transform(url.begin(),url.end(),url.begin(),tolower);
         std::string surl = urlmatch::strip_url(url);
@@ -268,10 +275,11 @@ namespace seeks_plugins
         free(csp->_http._gpc);
         csp->_http._gpc = strdup("delete");
         sp_err err = websearch::cgi_websearch_search(csp,rsp,parameters);
-        if (err != SP_ERR_OK) {
-          errlog::log_error(LOG_LEVEL_ERROR, "Returning err=%s", err);
-          return err;
-        }
+        if (err != SP_ERR_OK)
+          {
+            errlog::log_error(LOG_LEVEL_ERROR, "Returning err=%s", err);
+            return err;
+          }
         miscutil::unmap(const_cast<hash_map<const char*,const char*,hash<const char*>,eqstr>*>(parameters),"q");
         miscutil::unmap(const_cast<hash_map<const char*,const char*,hash<const char*>,eqstr>*>(parameters),"url");
         miscutil::unmap(const_cast<hash_map<const char*,const char*,hash<const char*>,eqstr>*>(parameters),"action");
@@ -302,10 +310,11 @@ namespace seeks_plugins
       {
         // check for query.
         const char *query_str = miscutil::lookup(parameters,"q");
-        if (!query_str || strlen(query_str) == 0) {
-          errlog::log_error(LOG_LEVEL_ERROR, "Returning SP_ERR_CGI_PARAMS: Parameter 'q' not given.");
-          return SP_ERR_CGI_PARAMS;
-        }
+        if (!query_str || strlen(query_str) == 0)
+          {
+            errlog::log_error(LOG_LEVEL_ERROR, "Returning SP_ERR_CGI_PARAMS: Parameter 'q' not given.");
+            return SP_ERR_CGI_PARAMS;
+          }
         char *enc_query = encode::url_encode(query_str);
         std::string query = enc_query;
         free(enc_query);
@@ -353,10 +362,11 @@ namespace seeks_plugins
       {
         // check for query.
         const char *query_str = miscutil::lookup(parameters,"q");
-        if (!query_str || strlen(query_str) == 0) {
-          errlog::log_error(LOG_LEVEL_ERROR, "Returning SP_ERR_CGI_PARAMS: Parameter 'q' not given.");
-          return SP_ERR_CGI_PARAMS;
-        }
+        if (!query_str || strlen(query_str) == 0)
+          {
+            errlog::log_error(LOG_LEVEL_ERROR, "Returning SP_ERR_CGI_PARAMS: Parameter 'q' not given.");
+            return SP_ERR_CGI_PARAMS;
+          }
         char *enc_query = encode::url_encode(query_str);
         std::string query = enc_query;
         free(enc_query);
@@ -368,10 +378,11 @@ namespace seeks_plugins
 
         // check for url.
         const char *url_str = miscutil::lookup(parameters,"url");
-        if (!url_str) {
-          errlog::log_error(LOG_LEVEL_ERROR, "Returning SP_ERR_CGI_PARAMS: Parameter 'url' not given.");
-          return SP_ERR_CGI_PARAMS;
-        }
+        if (!url_str)
+          {
+            errlog::log_error(LOG_LEVEL_ERROR, "Returning SP_ERR_CGI_PARAMS: Parameter 'url' not given.");
+            return SP_ERR_CGI_PARAMS;
+          }
         std::string url = url_str;
         std::transform(url.begin(),url.end(),url.begin(),tolower);
         std::string surl = urlmatch::strip_url(url);

--- a/src/plugins/websearch_api_compat/websearch_api_compat.cpp
+++ b/src/plugins/websearch_api_compat/websearch_api_compat.cpp
@@ -21,6 +21,7 @@
 #include "urlmatch.h"
 #include "encode.h"
 #include "mrf.h"
+#include "errlog.h"
 
 #ifdef FEATURE_IMG_WEBSEARCH_PLUGIN
 #include "img_websearch.h"
@@ -79,8 +80,11 @@ namespace seeks_plugins
       {
         // check for query.
         const char *query_str = miscutil::lookup(parameters,"q");
-        if (!query_str || strlen(query_str) == 0)
+        if (!query_str || strlen(query_str) == 0) {
+          errlog::log_error(LOG_LEVEL_ERROR, "Error SP_ERR_CGI_PARAMS: Parameter 'q' is not set or empty.");
           return SP_ERR_CGI_PARAMS;
+        }
+
         // cgi decodes the parameters, need to re-encode before passing it to websearch plugin.
         char *enc_query = encode::url_encode(query_str);
         std::string query = enc_query;
@@ -122,9 +126,17 @@ namespace seeks_plugins
             csp->_http._path = strdup(path.c_str());
             return websearch::cgi_websearch_similarity(csp,rsp,parameters);
           }
-        else return SP_ERR_CGI_PARAMS;
+        else
+          {
+            errlog::log_error(LOG_LEVEL_ERROR, "Returning SP_ERR_CGI_PARAMS: No 'action' given.");
+            return SP_ERR_CGI_PARAMS;
+          }
       }
-    else return SP_ERR_CGI_PARAMS;
+    else
+      {
+        errlog::log_error(LOG_LEVEL_ERROR, "Returning SP_ERR_CGI_PARAMS: No parameters given.");
+        return SP_ERR_CGI_PARAMS;
+      }
   }
 
   sp_err websearch_api_compat::cgi_search_cache_compat(client_state *csp,
@@ -135,8 +147,10 @@ namespace seeks_plugins
       {
         // check for query.
         const char *query_str = miscutil::lookup(parameters,"q");
-        if (!query_str || strlen(query_str) == 0)
+        if (!query_str || strlen(query_str) == 0) {
+          errlog::log_error(LOG_LEVEL_ERROR, "Error SP_ERR_CGI_PARAMS: 'q' is not set or empty.");
           return SP_ERR_CGI_PARAMS;
+        }
         char *enc_query = encode::url_encode(query_str);
         std::string query = enc_query;
         free(enc_query);
@@ -144,8 +158,10 @@ namespace seeks_plugins
 
         // check for url.
         const char *url_str = miscutil::lookup(parameters,"url");
-        if (!url_str)
+        if (!url_str) {
+          errlog::log_error(LOG_LEVEL_ERROR, "Error SP_ERR_CGI_PARAMS: 'url' is not set or empty.");
           return SP_ERR_CGI_PARAMS;
+        }
         std::string url = url_str;
         std::transform(url.begin(),url.end(),url.begin(),tolower);
         std::string surl = urlmatch::strip_url(url);
@@ -159,7 +175,11 @@ namespace seeks_plugins
         csp->_http._path = strdup(path.c_str());
         return websearch::cgi_websearch_search_cache(csp,rsp,parameters);
       }
-    else return SP_ERR_CGI_PARAMS;
+    else
+      {
+        errlog::log_error(LOG_LEVEL_ERROR, "Returning SP_ERR_CGI_PARAMS: No parameters given.");
+        return SP_ERR_CGI_PARAMS;
+      }
   }
 
   sp_err websearch_api_compat::cgi_qc_redir_compat(client_state *csp,
@@ -170,8 +190,10 @@ namespace seeks_plugins
       {
         // check for query.
         const char *query_str = miscutil::lookup(parameters,"q");
-        if (!query_str || strlen(query_str) == 0)
+        if (!query_str || strlen(query_str) == 0) {
+          errlog::log_error(LOG_LEVEL_ERROR, "Error SP_ERR_CGI_PARAMS: 'q' is not set or empty.");
           return SP_ERR_CGI_PARAMS;
+        }
         char *enc_query = encode::url_encode(query_str);
         std::string query = enc_query;
         free(enc_query);
@@ -183,8 +205,10 @@ namespace seeks_plugins
 
         // check for url.
         const char *url_str = miscutil::lookup(parameters,"url");
-        if (!url_str)
+        if (!url_str) {
+          errlog::log_error(LOG_LEVEL_ERROR, "Error SP_ERR_CGI_PARAMS: 'url' is not set or empty.");
           return SP_ERR_CGI_PARAMS;
+        }
         std::string url = url_str;
         std::transform(url.begin(),url.end(),url.begin(),tolower);
         std::string surl = urlmatch::strip_url(url);
@@ -200,7 +224,11 @@ namespace seeks_plugins
         csp->_http._gpc = strdup("post");
         return websearch::cgi_websearch_search(csp,rsp,parameters);
       }
-    else return SP_ERR_CGI_PARAMS;
+    else
+      {
+        errlog::log_error(LOG_LEVEL_ERROR, "Returning SP_ERR_CGI_PARAMS: No parameters given.");
+        return SP_ERR_CGI_PARAMS;
+      }
   }
 
   sp_err websearch_api_compat::cgi_tbd_compat(client_state *csp,
@@ -211,8 +239,10 @@ namespace seeks_plugins
       {
         // check for query.
         const char *query_str = miscutil::lookup(parameters,"q");
-        if (!query_str || strlen(query_str) == 0)
+        if (!query_str || strlen(query_str) == 0) {
+          errlog::log_error(LOG_LEVEL_ERROR, "Returning SP_ERR_CGI_PARAMS: Parameter 'q' not given.");
           return SP_ERR_CGI_PARAMS;
+        }
         char *enc_query = encode::url_encode(query_str);
         std::string query = enc_query;
         free(enc_query);
@@ -220,8 +250,10 @@ namespace seeks_plugins
 
         // check for url.
         const char *url_str = miscutil::lookup(parameters,"url");
-        if (!url_str)
+        if (!url_str) {
+          errlog::log_error(LOG_LEVEL_ERROR, "Returning SP_ERR_CGI_PARAMS: Parameter 'url' not given.");
           return SP_ERR_CGI_PARAMS;
+        }
         std::string url = url_str;
         std::transform(url.begin(),url.end(),url.begin(),tolower);
         std::string surl = urlmatch::strip_url(url);
@@ -236,8 +268,10 @@ namespace seeks_plugins
         free(csp->_http._gpc);
         csp->_http._gpc = strdup("delete");
         sp_err err = websearch::cgi_websearch_search(csp,rsp,parameters);
-        if (err != SP_ERR_OK)
+        if (err != SP_ERR_OK) {
+          errlog::log_error(LOG_LEVEL_ERROR, "Returning err=%s", err);
           return err;
+        }
         miscutil::unmap(const_cast<hash_map<const char*,const char*,hash<const char*>,eqstr>*>(parameters),"q");
         miscutil::unmap(const_cast<hash_map<const char*,const char*,hash<const char*>,eqstr>*>(parameters),"url");
         miscutil::unmap(const_cast<hash_map<const char*,const char*,hash<const char*>,eqstr>*>(parameters),"action");
@@ -252,7 +286,11 @@ namespace seeks_plugins
         csp->_http._path = strdup(path.c_str());
         return websearch::cgi_websearch_search(csp,rsp,parameters);
       }
-    else return SP_ERR_CGI_PARAMS;
+    else
+      {
+        errlog::log_error(LOG_LEVEL_ERROR, "Returning SP_ERR_CGI_PARAMS: No parameters given.");
+        return SP_ERR_CGI_PARAMS;
+      }
   }
 
 #ifdef FEATURE_IMG_WEBSEARCH_PLUGIN
@@ -264,8 +302,10 @@ namespace seeks_plugins
       {
         // check for query.
         const char *query_str = miscutil::lookup(parameters,"q");
-        if (!query_str || strlen(query_str) == 0)
+        if (!query_str || strlen(query_str) == 0) {
+          errlog::log_error(LOG_LEVEL_ERROR, "Returning SP_ERR_CGI_PARAMS: Parameter 'q' not given.");
           return SP_ERR_CGI_PARAMS;
+        }
         char *enc_query = encode::url_encode(query_str);
         std::string query = enc_query;
         free(enc_query);
@@ -292,9 +332,17 @@ namespace seeks_plugins
             return img_websearch::cgi_img_websearch_similarity(csp,rsp,parameters);
           }
 #endif
-        else return SP_ERR_CGI_PARAMS;
+        else
+          {
+            errlog::log_error(LOG_LEVEL_ERROR, "Returning SP_ERR_CGI_PARAMS: Parameter 'action' not given.");
+            return SP_ERR_CGI_PARAMS;
+          }
       }
-    else return SP_ERR_CGI_PARAMS;
+    else
+      {
+        errlog::log_error(LOG_LEVEL_ERROR, "Returning SP_ERR_CGI_PARAMS: No paramters given.");
+        return SP_ERR_CGI_PARAMS;
+      }
   }
 
   sp_err websearch_api_compat::cgi_img_qc_redir_compat(client_state *csp,
@@ -305,8 +353,10 @@ namespace seeks_plugins
       {
         // check for query.
         const char *query_str = miscutil::lookup(parameters,"q");
-        if (!query_str || strlen(query_str) == 0)
+        if (!query_str || strlen(query_str) == 0) {
+          errlog::log_error(LOG_LEVEL_ERROR, "Returning SP_ERR_CGI_PARAMS: Parameter 'q' not given.");
           return SP_ERR_CGI_PARAMS;
+        }
         char *enc_query = encode::url_encode(query_str);
         std::string query = enc_query;
         free(enc_query);
@@ -318,8 +368,10 @@ namespace seeks_plugins
 
         // check for url.
         const char *url_str = miscutil::lookup(parameters,"url");
-        if (!url_str)
+        if (!url_str) {
+          errlog::log_error(LOG_LEVEL_ERROR, "Returning SP_ERR_CGI_PARAMS: Parameter 'url' not given.");
           return SP_ERR_CGI_PARAMS;
+        }
         std::string url = url_str;
         std::transform(url.begin(),url.end(),url.begin(),tolower);
         std::string surl = urlmatch::strip_url(url);
@@ -335,7 +387,11 @@ namespace seeks_plugins
         csp->_http._gpc = strdup("post");
         return img_websearch::cgi_img_websearch_search(csp,rsp,parameters);
       }
-    else return SP_ERR_CGI_PARAMS;
+    else
+      {
+        errlog::log_error(LOG_LEVEL_ERROR, "Returning SP_ERR_CGI_PARAMS: No parameter given.");
+        return SP_ERR_CGI_PARAMS;
+      }
   }
 #endif
 

--- a/src/proxy/Makefile.am
+++ b/src/proxy/Makefile.am
@@ -16,7 +16,8 @@ endif
 lib_LTLIBRARIES += libseeksproxy.la libseeksplugins.la
 
 libseeksproxy_la_CXXFLAGS=-Wall -Wno-deprecated -g -pipe \
-	               -I${srcdir} -I${srcdir}/../utils -I${srcdir}/../lsh
+	               -I${srcdir} -I${srcdir}/../utils -I${srcdir}/../lsh \
+	               -I${srcdir}/../plugins/udb_service
 libseeksproxy_la_SOURCES=seeks_proxy.cpp proxy_dts.cpp errlog.cpp \
                         cgi.cpp encode.cpp spsockets.cpp filters.cpp gateway.cpp\
                         parsers.cpp pcrs.cpp cgisimple.cpp loaders.cpp \

--- a/src/proxy/Makefile.am
+++ b/src/proxy/Makefile.am
@@ -136,6 +136,7 @@ EXTRA_DIST = \
 	    templates/cgi-error-disabled \
 	    templates/cgi-error-file \
 	    templates/cgi-error-file-read-only \
+	    templates/cgi-error-forbidden \
 	    templates/cgi-error-modified \
 	    templates/cgi-error-parse \
 	    templates/cgi-error-plugin \

--- a/src/proxy/cgi.cpp
+++ b/src/proxy/cgi.cpp
@@ -584,8 +584,8 @@ namespace sp
           {
             /* internal plugin error. */
             errlog::log_error(LOG_LEVEL_ERROR,
-                              "%d in plugin %s caught in top-level handler",
-                              err, d->_plugin_name.c_str());
+                              "%d (%s) in plugin %s caught in top-level handler",
+                              err, errlog::sp_err_to_string(err), d->_plugin_name.c_str());
             err = cgi::cgi_error_plugin(csp, rsp, err, d->_plugin_name, param_list);
           }
       }

--- a/src/proxy/cgi.cpp
+++ b/src/proxy/cgi.cpp
@@ -2287,7 +2287,7 @@ namespace sp
     if (hostname)
       freez(hostname);
     hostname = NULL;
-    if (!err) err = miscutil::add_map_entry(exports, "homepage",      1, encode::html_encode(HOME_PAGE_URL), 0);
+    if (!err) err = miscutil::add_map_entry(exports, "homepage",      1, encode::html_encode(SEARCH_PHP_URL), 0);
     if (!err) err = miscutil::add_map_entry(exports, "default-cgi",   1, encode::html_encode(CGI_PREFIX), 0);
     if (!err) err = miscutil::add_map_entry(exports, "menu",          1,
                                               cgi::make_menu(caller, csp->_config->_feature_flags), 0);

--- a/src/proxy/cgi.cpp
+++ b/src/proxy/cgi.cpp
@@ -234,6 +234,8 @@ namespace sp
    *********************************************************************/
   http_response* cgi::dispatch_cgi(client_state *csp)
   {
+    errlog::log_error(LOG_LEVEL_DEBUG, "cgi::dispatch_cgi(): CALLED!");
+
     const char *host = csp->_http._host;
     const char *path = csp->_http._path;
 
@@ -276,6 +278,7 @@ namespace sp
     /*
      * This is a CGI call.
      */
+    errlog::log_error(LOG_LEVEL_DEBUG, "cgi::dispatch_cgi(): Calling cgi::dispatch_known_cgi() with path %s", path);
     return cgi::dispatch_known_cgi(csp, path);
   }
 
@@ -494,6 +497,7 @@ namespace sp
 
         if ((strcmp(path_copy, d->_name) == 0))
           {
+            errlog::log_error(LOG_LEVEL_DEBUG, "cgi::dispatch_known_cgi(): Calling generic cgi::dispatch() for %s ...", d->_name);
             return cgi::dispatch(d, path_copy, csp, param_list, rsp);
           }
 
@@ -506,6 +510,8 @@ namespace sp
     d = plugin_manager::find_plugin_cgi_dispatcher(path_copy);
     if (d)
       {
+        errlog::log_error(LOG_LEVEL_DEBUG, "cgi::dispatch_known_cgi(): csp->_iob._cur=%s,_buf=%s", csp->_iob._cur, csp->_iob._buf);
+        errlog::log_error(LOG_LEVEL_DEBUG, "cgi::dispatch_known_cgi(): Calling cgi::dispatch() for %s ...", d->_name);
         return cgi::dispatch(d, path_copy, csp, param_list, rsp);
       }
 
@@ -534,7 +540,9 @@ namespace sp
      */
     if (d->_harmless || cgi::referrer_is_safe(csp))
       {
+        errlog::log_error(LOG_LEVEL_DEBUG, "cgi::dispatch(): Calling handler for %s ...", d->_name);
         err = (d->_handler)(csp, rsp, param_list);
+        errlog::log_error(LOG_LEVEL_DEBUG, "cgi::dispatch(): Handler returned err=%d", err);
       }
     else
       {
@@ -1257,7 +1265,7 @@ namespace sp
       }
     if (output == "json")
       {
-        rsp->_status = strdup("500");
+        rsp->_status = strdup("500 Internal Server Error");
         rsp->_body = strdup("{\"error\":\"internal plugin error\"}");
         rsp->_content_length = strlen(rsp->_body);
         return SP_ERR_OK;

--- a/src/proxy/errlog.cpp
+++ b/src/proxy/errlog.cpp
@@ -64,6 +64,7 @@
 #endif /* def _MSC_VER */
 
 #include "errlog.h"
+#include "udbs_err.h"
 //#include "seeks_proxy.h"
 
 namespace sp
@@ -876,6 +877,12 @@ namespace sp
         return "File has been modified outside of the CGI actions editor.";
       case SP_ERR_COMPRESS:
         return "(De)compression failure";
+      case UDBS_ERR_SERIALIZE:
+        return "msg serialization error.";
+      case UDBS_ERR_DESERIALIZE:
+        return "msg deserialization error.";
+      case UDBS_ERR_CONNECT:
+        return "peer connection error.";
       default:
         assert(0);
         return "Unknown error";

--- a/src/proxy/parsers.cpp
+++ b/src/proxy/parsers.cpp
@@ -228,6 +228,7 @@ namespace sp
    *********************************************************************/
   sp_err parsers::add_to_iob(client_state *csp, char *buf, long n)
   {
+    errlog::log_error(LOG_LEVEL_DEBUG, "parsers::add_to_iob(): buf=%s, n=%d - CALLED!", buf, n);
     iob *iob = &csp->_iob;
     size_t used, offset, need, want;
     char *p;
@@ -610,6 +611,7 @@ namespace sp
     csp->_iob._buf = NULL;
 
     /* Now, update the iob to use the new buffer. */
+    errlog::log_error(LOG_LEVEL_DEBUG, "parsers::decompress_iob(): Reached!");
     csp->_iob._buf  = buf;
     csp->_iob._cur  = csp->_iob._buf + skip_size;
     csp->_iob._eod  = (char *)zstr.next_out;
@@ -3543,7 +3545,7 @@ namespace sp
    *********************************************************************/
   sp_err parsers::server_proxy_connection_adder(client_state *csp)
   {
-    static const char proxy_connection_header[] = "Proxy-Connection: keep-alive";
+    static const char proxy_connection_header[] = "Proxy-Connection: Keep-Alive";
     sp_err err = SP_ERR_OK;
 
     if ((csp->_flags & CSP_FLAG_CLIENT_CONNECTION_KEEP_ALIVE)

--- a/src/proxy/proxy_dts.h
+++ b/src/proxy/proxy_dts.h
@@ -1114,6 +1114,9 @@ namespace sp
   /** URL for the Seeks home page. */
 #define HOME_PAGE_URL     "http://www.seeks-project.info/"
 
+  /** URL for search.php calls */
+#define SEARCH_PHP_URL    "https://seeks.mxchange.org/"
+
   /** URL for the Seeks user manual. */
 #define USER_MANUAL_URL   HOME_PAGE_URL VERSION "/user-manual/"
 

--- a/src/proxy/seeks_proxy.cpp
+++ b/src/proxy/seeks_proxy.cpp
@@ -966,6 +966,7 @@ namespace sp
          * If there is no memory left for buffering the
          * request, there is nothing we can do but hang up
          */
+        errlog::log_error(LOG_LEVEL_DEBUG, "seeks_proxy::get_request_line(): Calling parsers::add_to_iob(???,%s,%d) ...", buf, len);
         if (parsers::add_to_iob(csp, buf, len))
           {
             return NULL;
@@ -1066,6 +1067,8 @@ namespace sp
                 errlog::log_error(LOG_LEVEL_ERROR, "read from client failed: %E");
                 return SP_ERR_PARSE;
               }
+
+            errlog::log_error(LOG_LEVEL_DEBUG, "seeks_proxy::receive_client_request(): Calling parsers::add_to_iob(???,%s,%d) ...", buf, len);
             if (parsers::add_to_iob(csp, buf, len))
               {
                 /*
@@ -1347,6 +1350,8 @@ namespace sp
     *                +--------+--------+
     *
     */
+
+    errlog::log_error(LOG_LEVEL_DEBUG, "seeks_proxy::chat(): _cur=%s,_eod=%s,%E", csp->_iob._cur, csp->_iob._eod, sizeof(csp->_iob));
 
     if (http->_ssl == 0)
       {
@@ -1812,6 +1817,7 @@ reading_done:
                      * has been reached, switch to non-filtering mode, i.e. make & write the
                      * header, flush the iob and buf, and get out of the way.
                      */
+                    errlog::log_error(LOG_LEVEL_DEBUG, "seeks_proxy::chat(): Calling parsers::add_to_iob(???,%s,%d) ...", buf, len);
                     if (parsers::add_to_iob(csp, buf, len))
                       {
                         size_t hdrlen;
@@ -1878,6 +1884,7 @@ reading_done:
                 * Buffer up the data we just read.  If that fails, there's
                 * little we can do but send our static out-of-memory page.
                 */
+                errlog::log_error(LOG_LEVEL_DEBUG, "seeks_proxy::chat(): Calling parsers::add_to_iob(???,%s,%d) ... #2", buf, len);
                 if (parsers::add_to_iob(csp, buf, len))
                   {
                     errlog::log_error(LOG_LEVEL_ERROR, "Out of memory while looking for end of server headers.");
@@ -2135,6 +2142,7 @@ reading_done:
 
     do
       {
+        errlog::log_error(LOG_LEVEL_DEBUG, "seeks_proxy::serve(): Calling seeks_proxy::chat(csp) for defined FEATURE_CONNECTION_KEEP_ALIVE ...");
         seeks_proxy::chat(csp);
 
         if ((csp->_flags & CSP_FLAG_SERVER_CONNECTION_KEEP_ALIVE)
@@ -2226,6 +2234,7 @@ reading_done:
 
     gateway::mark_connection_closed(&csp->_server_connection);
 #else
+    errlog::log_error(LOG_LEVEL_DEBUG, "seeks_proxy::serve(): Calling seeks_proxy::chat(csp) for undefined FEATURE_CONNECTION_KEEP_ALIVE.");
     seeks_proxy::chat(csp);
 #endif /* def FEATURE_CONNECTION_KEEP_ALIVE */
 
@@ -2578,6 +2587,7 @@ reading_done:
 #ifdef FEATURE_TOGGLE
                 int inherited_toggle_state = seeks_proxy::_global_toggle_state;
 # endif /* def FEATURE_TOGGLE */
+                errlog::log_error(LOG_LEVEL_DEBUG, "seeks_proxy::listen_loop(): Calling seeks_proxy::serve(csp) ...");
                 seeks_proxy::serve(csp);
 
                 /*
@@ -2655,6 +2665,7 @@ reading_done:
           }
         else
           {
+            errlog::log_error(LOG_LEVEL_DEBUG, "seeks_proxy::listen_loop(): Calling seeks_proxy::serve(csp) in else block");
             seeks_proxy::serve(csp);
           }
       }

--- a/src/proxy/templates/cgi-error-forbidden
+++ b/src/proxy/templates/cgi-error-forbidden
@@ -1,0 +1,132 @@
+##########################################################
+#
+# Forbidden Error Output template for Privoxy.
+#
+#
+# USING HTML TEMPLATES:
+# ---------------------
+#
+# Template files are written win plain HTML, with a few
+# additions:
+# 
+# - Lines that start with a '#' character like this one
+#   are ignored
+#
+# - Each item in the below list of exported symbols will
+#   be replaced by dynamically generated text, if they
+#   are enclosed in '@'-characters. E.g. The string @version@
+#   will be replaced by the version number of Privoxy.
+#
+# - One special application of this is to make whole blocks
+#   of the HTML template disappear if the condition <name>
+#   is not given. Simply enclose the block between the two
+#   strings @if-<name>start and if-<name>-end@. The strings
+#   should be placed in HTML comments (<!-- -->), so the
+#   html structure won't be messed when the magic happens.
+#   
+# USABLE SYMBOLS IN THIS TEMPLATE:
+# --------------------------------
+#
+#  my-ip-addr:
+#    The IP-address that the client used to reach this proxy
+#  my-hostname:
+#    The hostname associated with my-ip-addr
+#  admin-address:
+#    The email address of the pxoxy's administrator, as configured
+#    in the config file
+#  default-cgi:
+#    The URL for the "main menu" builtin CGI of this proxy
+#  menu:
+#    List of <li> elements linking to the other available CGIs
+#  version:
+#    The version number of the proxy software
+#  code-status:
+#    The development status of the proxy software: "alpha", "beta",
+#    or "stable".
+#  homepage:
+#    The URL of the SourceForge ijbswa project, who maintains this
+#    software.
+#
+# CONDITIONAL SYMBOLS FOR THIS TEMPLATE AND THEIR DEPANDANT SYMBOLS:
+# ------------------------------------------------------------------
+#
+#  unstable:
+#    this is an alpha or beta release of the proxy software
+#  have-adminaddr-info:
+#    An e-mail address for the local Privoxy adminstrator has
+#    been specified and is available through the "admin-address"
+#    symbol
+#  have-proxy-info:
+#    A URL for online documentation about this proxy has been
+#    specified and is available through the "proxy-info-url"
+#    symbol
+#  have-help-info:
+#    If either have-proxy-info is true or have-adminaddr-info is
+#    true, have-help-info is true.  Used to conditionally include
+#    a grey box for any and all help info.
+#
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+
+<head>
+  <title>403 - Seeks Forbidden</title>
+  <meta http-equiv="Content-Style-Type" content="text/css">
+  <meta http-equiv="Content-Script-Type" content="text/javascript">
+  <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+  <meta name="robots" content="noindex,nofollow">
+  <link rel="stylesheet" type="text/css" href="@default-cgi@send-stylesheet">
+  <link rel="shortcut icon" href="@default-cgi@error-favicon.ico">
+</head>
+
+<body>
+
+  <table cellpadding="20" cellspacing="10" border="0" width="100%">
+    <tr>
+      <td class="status">
+        403
+      </td>     
+      <td class="title" style="width: 100%">
+
+#include mod-title
+
+      </td>
+    </tr>
+
+<!-- @if-unstable-start -->
+# This will only appear if CODE_STATUS is "alpha" or "beta". See configure.in
+    <tr>
+      <td class="warning" colspan="2">
+
+#include mod-unstable-warning
+
+      </td>
+    </tr>
+<!-- if-unstable-end@ -->
+
+    <tr>
+      <td class="warning" colspan="2">
+        <h2>Seeks forbidden</h2>
+            <p>You don't have access to the page you have requested.</p>
+            <p>If you got here by clicking a link in the
+               interface, please file a bug report!</p>
+        </td>
+    </tr>
+
+    <tr>
+      <td class="box" colspan="2">
+        <h2>More:</h2>
+        <ul>@menu@<li><a href="@user-manual@">Documentation</a></li></ul>
+      </td>
+    </tr>
+
+    <tr>
+      <td class="info" colspan="2">
+
+#include mod-support-and-service
+
+      </td>
+    </tr>
+  </table>
+
+</body>
+</html>


### PR DESCRIPTION
There is an error when I use the proto file _db_query_record_msg.proto_:

_db_query_record_msg.proto:36:11: Message extensions cannot have required fields.
/home/quix0r/git/seeks/src/plugins/query_capture/Makefile:850: recipe for target 'db_query_record_msg.pb.cc' failed
make: **\* [db_query_record_msg.pb.cc] Error 1_

This small change fixes it.
